### PR TITLE
partial support

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports.bindEvent = function ( fn, eventName, handler, context, removeCac
         _fns[eventName] = {};
     }
     if ( !_fns[ eventName ][ handlerString ] ) {
-        _fns[ eventName ][ handlerString ] = handler.bind( context );
+        _fns[ eventName ][ handlerString ] = handler.bind.apply( handler, context );
     }
     handler = _fns[ eventName ][ handlerString ];
 
@@ -28,14 +28,14 @@ module.exports.bindEvent = function ( fn, eventName, handler, context, removeCac
     if ( removeCache ) {
         delete _fns[ eventName ][ handlerString ];
     }
-}
+};
 
 var getMethod =
 module.exports.getMethod = function ( handleName, context ) {
     if ( typeof context !== 'object' ) {
         return;
     }
-    return ( context || window )[ handleName ];
+    return typeof handleName === 'function' ? handleName : ( context || window )[ handleName ];
 };
 
 var eachEvent = 
@@ -46,22 +46,26 @@ module.exports.eachEvent = function ( fn, eventObj, context, removeCache ) {
     for ( var _event in eventObj ) {
         event = eventObj[ _event ];
         if ( Array.isArray( event ) ) {
-            if ( typeof event[ 0 ] === 'object' ) {
+            if ( typeof event[ 0 ] === 'object' && !context ) {
                 bindTo = event[ 0 ];
                 if ( typeof event[ 1 ]  === 'string' ) {
                     eventHandle = getMethod( event[ 1 ], bindTo );
                 } else {
                     eventHandle = event[ 1 ];
                 }
+                bindTo = [ bindTo ];
             } else {
-                eventHandle = event[ 1 ];
+                eventHandle = getMethod( event.shift(), context );
+                event.unshift( context );
+                bindTo = event;
             }
         } else if ( typeof event === 'string' ) {
             eventHandle = getMethod( event, context );
         } else {
             eventHandle = event;
         }
-        bindEvent( fn, _event, eventHandle, bindTo || context, removeCache );
+
+        bindEvent( fn, _event, eventHandle, bindTo || [ context ], removeCache );
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bound",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "A simple module to help streamline event binding",
   "main": "index.js",
   "directories": {
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "expect": "~0.1.1",
-    "component-emitter": "~1.1.2"
+    "component-emitter": "~1.1.2",
+    "mocha": "~1.21.4"
   },
   "repostiory": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -21,9 +21,10 @@ describe( 'bound', function ( ) {
                 done();
             }
             // need to bind this
-            bound.bindEvent( emitter.on.bind(emitter), 'test', handle, { test : 'yeah' });
+            bound.bindEvent( emitter.on.bind(emitter), 'test', handle, [{ test : 'yeah' }]);
             emitter.emit('test', 'hello');
         });
+
     });
     describe( '#eachEvent', function ( ) {
         it('should bind each event given in a object to the function given', function ( done ) {
@@ -45,7 +46,7 @@ describe( 'bound', function ( ) {
             emitter.emit('test2.another', 'hello');
         });
 
-        it('should bind to the event emitter and also bind context ( first param ) of the handler ( second param ) when array is given', function ( done ) {
+        it('should bind to the event emitter and also bind context ( first param ) of the handler ( second param ) when array is given and no context is given', function ( done ) {
             function handle ( msg ) {
                 assert.equal( 'hello', msg );
                 assert.equal( true, this.testing );
@@ -62,6 +63,29 @@ describe( 'bound', function ( ) {
             });
             emitter.emit('test3', 'hello');
             emitter.emit('test3.another', 'jeeze');
+        });
+
+        it('should bind a function in the first param in an array, and the bind the nth other items in the array as a partial when an array is given as a value and a context is given as the third param', function ( done ) {
+            function handleFoo ( msg, opts ) {
+                assert.equal( 'foo', msg );
+                assert.equal( 'object', typeof opts );
+                assert.equal( 'qux', opts.baz );
+                assert.equal( 'bar', this.foo );
+                assert.equal( 'qux', this.baz );
+            }
+            function handleBar ( msg ) {
+                assert.equal( 'bar', msg );
+                assert.equal( 'bar', this.foo );
+                assert.equal( 'qux', this.baz );
+                done();
+            }
+            // need to bind this
+            bound.eachEvent( emitter.on.bind( emitter ), {
+                'testFoo': [ handleFoo, 'foo', { baz: 'qux' } ],
+                'testBar': [ handleBar, 'bar' ]
+            }, { foo: 'bar', baz: 'qux' } );
+            emitter.emit('testFoo', 'qux');
+            emitter.emit('testBar', 'baz');
         });
 
         it('should bind to the event emitter to method from the context when a string is given', function ( done ) {


### PR DESCRIPTION
through arrays

```javascript
bound( emitter, {
    'eventName': [ handler, 1, { foo: 'bar' } ]
}, { baz: 'qux' } );

function handler( num, obj, msg ) {
     console.log( num, obj, msg, this.baz ); // 1, { foo: 'bar' }, 'foo', 'qux'
} );

emitter.emit( 'eventName', 'foo' );
```

String names will also work!

> Important to know there is a feature that also uses Arrays that is undocumented.

```javascript
bound( emitter, {
    'eventName': [ context, handler ]
});

// the difference is that no context is passed in as the third param.
````